### PR TITLE
jhbuild: use http for mesa-gitlab repository

### DIFF
--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -10,7 +10,7 @@
   <repository type="git" name="wayland" default="yes"
       href="git://anongit.freedesktop.org/git/wayland"/>
   <repository type="git" name="mesa-gitlab" default="yes"
-      href="git@gitlab.freedesktop.org:mesa"/>
+      href="https://gitlab.freedesktop.org/mesa"/>
   <repository type="git" name="xorg-util" default="yes"
       href="git://anongit.freedesktop.org/git/xorg/util"/>
   <repository type="git" name="xorgproto" default="yes"


### PR DESCRIPTION
This allows anonymous access, without requiring pushing a SSH key