### PR TITLE
jhbuild: use jhbuildrc-expert with the custom scripts

### DIFF
--- a/jhbuild/jhbuild-compile.sh
+++ b/jhbuild/jhbuild-compile.sh
@@ -19,6 +19,6 @@ fi
 pushd ${JHBUILD_MESA_ROOT}/jhbuild.git && git pull
 ./autogen.sh --prefix=${JHBUILD_MESA_ROOT}/jhbuild-install && make && make install
 popd
-#${JHBUILD_MESA_ROOT}/jhbuild-install/bin/jhbuild -f ${FULL_BASE_PATH}/jhbuildrc-basic sysdeps --install
-#${JHBUILD_MESA_ROOT}/jhbuild-install/bin/jhbuild -f ${FULL_BASE_PATH}/jhbuildrc-basic build -f --nodeps
-${JHBUILD_MESA_ROOT}/jhbuild-install/bin/jhbuild -f ${FULL_BASE_PATH}/jhbuildrc-basic build --nodeps
+#${JHBUILD_MESA_ROOT}/jhbuild-install/bin/jhbuild -f ${FULL_BASE_PATH}/jhbuildrc-expert sysdeps --install
+#${JHBUILD_MESA_ROOT}/jhbuild-install/bin/jhbuild -f ${FULL_BASE_PATH}/jhbuildrc-expert build -f --nodeps
+${JHBUILD_MESA_ROOT}/jhbuild-install/bin/jhbuild -f ${FULL_BASE_PATH}/jhbuildrc-expert build --nodeps

--- a/jhbuild/jhbuild.sh
+++ b/jhbuild/jhbuild.sh
@@ -11,4 +11,4 @@
 
 source ./jhbuild-helper.sh
 
-${JHBUILD_MESA_ROOT}/jhbuild-install/bin/jhbuild -f ${FULL_BASE_PATH}/jhbuildrc-basic $@
+${JHBUILD_MESA_ROOT}/jhbuild-install/bin/jhbuild -f ${FULL_BASE_PATH}/jhbuildrc-expert $@


### PR DESCRIPTION
I'm not sure what was complicated in the jhbuildrc-expert to need be replaced by another more basic one but the custom scripts won't work any more unless we transition to use it.