### PR TITLE
Add cts-db-run

### DIFF
--- a/testing/cts-db-run.sh
+++ b/testing/cts-db-run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Emulates shader-db run output using Vulkan or OpenGL CTS deqp runner instead.
+# As it captures vertex/fragment/computer shader NIR/ASM output, it only works
+# with Intel.  Then you can use shader-db report to generate final report.
+#
+# WARNING: it executes each test separately 3 times, in order to get results for
+# each of the shader; try to keep the list of tests limited.
+
+
+if [ $# != 2 ]; then
+    echo "Usage: $0 <path-to-deqp-runner> <list-of-tests>"
+    exit 0
+fi
+
+RUNNER=$1
+TESTS=$2
+
+TESTLIST=`$1 -n $2 --deqp-runmode=stdout-caselist | grep TEST: | cut -c 7-`
+for t in $TESTLIST ; do
+    export INTEL_DEBUG=vs
+    RESULTS=`$1 -n $t 2>&1 | grep instructions | sed "s/\./,/g"`
+    if [ -n "$RESULTS" ]; then
+        echo "$t - VS $RESULTS"
+    fi
+    export INTEL_DEBUG=fs
+    RESULTS=`$1 -n $t 2>&1 | grep instructions | sed "s/\./,/g"`
+    if [ -n "$RESULTS" ]; then
+        echo "$t - FS $RESULTS"
+    fi
+    export INTEL_DEBUG=cs
+    RESULTS=`$1 -n $t 2>&1 | grep instructions | sed "s/\./,/g"`
+    if [ -n "$RESULTS" ]; then
+        echo "$t - CS $RESULTS"
+    fi
+done


### PR DESCRIPTION
shader-db is an interesting tool to test the impact of changes in Mesa
code that can affect the final shader assembly code.

Unfortunately, shader-db uses OpenGL, so if the changes are done in the
Vulkan part, it won't show any result.

This tool tries to emulate the same behaviour, but using the shaders in
Vulkan/OpenGL CTS testsuite.

The output is the same as the output obtained with shader-db/run, so
shader-db/report tool can be used later to generate the final report.