### PR TITLE
jhbuild: Update the required meson version

### DIFF
--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -39,7 +39,7 @@
 
   <distutils id="meson" python3="1">
     <branch repo="github-tar"
-            version="0.49.0"
+            version="0.52.0"
             module="mesonbuild/meson/releases/download/${version}/meson-${version}.tar.gz"
             checkoutdir="meson-${version}">
     </branch>


### PR DESCRIPTION
Since c1a290bdd5, Mesa requires meson version 0.52.