### PR TITLE
jhbuild: Remove drm from --platforms in mesonargs for Mesa

### DIFF
--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -131,7 +131,7 @@
     <branch repo="wayland"/>
   </autotools>
 
-  <meson id="mesa" mesonargs="-Dplatforms=x11,drm -Dgallium-drivers=">
+  <meson id="mesa" mesonargs="-Dplatforms=x11 -Dgallium-drivers=">
     <branch repo="mesa-gitlab" branch="9.1"/>
     <dependencies>
       <dep package="meson"/>


### PR DESCRIPTION
Apparently the drm and surfaceless platforms are now built unconditionally and since commit [f8dc22bf61c1e6008f](https://gitlab.freedesktop.org/mesa/mesa/-/commit/f8dc22bf61c1e6008f) the build script no longer accepts these in the `--platforms` option.