### PR TITLE
Use meson for weston and its dependencies

### DIFF
--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -250,14 +250,14 @@
     <branch repo="xorg-lib"/>
   </autotools>
 
-  <autotools id="libxkbcommon" autogenargs="--with-xkb-config-root=/usr/share/X11/xkb">
+  <meson id="libxkbcommon" mesonargs="-Dxkb-config-root=/usr/share/X11/xkb">
     <branch repo="github" module="xkbcommon/libxkbcommon.git"/>
     <dependencies>
       <dep package="macros"/>
       <dep package="xproto"/>
       <dep package="libX11"/>
     </dependencies>
-  </autotools>
+  </meson>
 
 
   <meson id="glib">

--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -260,9 +260,9 @@
   </autotools>
 
 
-  <autotools id="glib">
+  <meson id="glib">
     <branch repo="gnome"/>
-  </autotools>
+  </meson>
 
   <autotools id="gobject-introspection">
     <branch repo="gnome"/>

--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -217,14 +217,14 @@
     <branch repo="wayland"/>
   </autotools>
 
-  <autotools id="weston" autogenargs="--disable-setuid-install">
+  <meson id="weston">
     <branch repo="wayland"/>
     <dependencies>
       <dep package="wayland"/>
       <dep package="cairo"/>
       <dep package="libxkbcommon"/>
     </dependencies>
-  </autotools>
+  </meson>
 
   <autotools id="macros">
     <branch repo="xorg-util"/>

--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -217,7 +217,7 @@
     <branch repo="wayland"/>
   </autotools>
 
-  <meson id="weston">
+  <meson id="weston" mesonargs="-Dbackend-rdp=false -Dcolor-management-lcms=false -Dcolor-management-colord=false -Dremoting=false -Dpipewire=false">
     <branch repo="wayland"/>
     <dependencies>
       <dep package="wayland"/>

--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -250,7 +250,7 @@
     <branch repo="xorg-lib"/>
   </autotools>
 
-  <meson id="libxkbcommon" mesonargs="-Dxkb-config-root=/usr/share/X11/xkb">
+  <meson id="libxkbcommon" mesonargs="-Dxkb-config-root=/usr/share/X11/xkb -Denable-docs=false">
     <branch repo="github" module="xkbcommon/libxkbcommon.git"/>
     <dependencies>
       <dep package="macros"/>

--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -213,7 +213,7 @@
     </dependencies>
   </autotools>
 
-  <autotools id="wayland" autogenargs="--with-egl-platforms=wayland,drm,x11">
+  <autotools id="wayland" autogenargs="--with-egl-platforms=wayland,drm,x11 --disable-documentation">
     <branch repo="wayland"/>
   </autotools>
 


### PR DESCRIPTION
This fixes some things to make it easier to build Weston, notably by switching some packages to Meson that have removed support for autotools.