### PR TITLE
Add igt-gpu-tools to jhbuild

### DIFF
--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -129,6 +129,10 @@
 
   <autotools id="wayland-protocols">
     <branch repo="wayland" revision="main"/>
+    <dependencies>
+      <!-- for wayland-scanner -->
+      <dep package="wayland"/>
+    </dependencies>
   </autotools>
 
   <meson id="mesa" mesonargs="-Dplatforms=x11 -Dgallium-drivers=">

--- a/jhbuild/graphics-mesa.modules
+++ b/jhbuild/graphics-mesa.modules
@@ -11,6 +11,8 @@
       href="git://anongit.freedesktop.org/git/wayland"/>
   <repository type="git" name="mesa-gitlab" default="yes"
       href="https://gitlab.freedesktop.org/mesa"/>
+  <repository type="git" name="drm-gitlab" default="yes"
+      href="https://gitlab.freedesktop.org/drm"/>
   <repository type="git" name="xorg-util" default="yes"
       href="git://anongit.freedesktop.org/git/xorg/util"/>
   <repository type="git" name="xorgproto" default="yes"
@@ -360,4 +362,12 @@
   <cmake id="freerdp">
     <branch repo="github" module="FreeRDP/FreeRDP" revision="master"/>
   </cmake>
+
+  <meson id="igt-gpu-tools">
+    <branch repo="drm-gitlab"/>
+    <dependencies>
+      <dep package="drm"/>
+      <dep package="cairo"/>
+    </dependencies>
+  </meson>
 </moduleset>


### PR DESCRIPTION
The second patch adds igt-gpu-tools to the jhbuild.

The first patch isn’t really related but it fixes the ordering for building wayland.